### PR TITLE
moves database initialization to a hook to eliminate sails bootstrap war...

### DIFF
--- a/backend/api/hooks/load-db.js
+++ b/backend/api/hooks/load-db.js
@@ -1,0 +1,19 @@
+module.exports = function ( sails ) {
+
+  return {
+
+//    configure:function () {
+//      // opportunity to do hook configuration here
+//      sails.log.info('load-db hook configuration done');
+//    },
+
+    initialize:function ( cb ) {
+
+      sails.after( 'hook:orm:loaded', function () {
+        sails.services['database'].init(cb);
+      } );
+      // sails.log.info('load-db hook initialized');
+    }
+  }
+
+}

--- a/backend/config/bootstrap.js
+++ b/backend/config/bootstrap.js
@@ -22,6 +22,6 @@ module.exports.bootstrap = function(next) {
         sails.services['logger'].request(request);
     });
 
-    // Initialize backend database
-    sails.services['database'].init(next);
+    next();
+
 };


### PR DESCRIPTION
Initializing database service directly in `bootstrap.js` often causes sails to issue a warning of slow bootstrap in cases where a database other than `localDiskDb` is used, especially if a large amount of data is being seeded.  This PR creates a hook attached to 'hook:orm:loaded', which may be a more natural place to perform this task, and also removes the warning.
