### PR TITLE
Fixed treatment of jwt.verify() returning empty error

### DIFF
--- a/backend/api/policies/Authenticated.js
+++ b/backend/api/policies/Authenticated.js
@@ -46,17 +46,17 @@ module.exports = function(request, response, next) {
 
     // Verify JWT token via service
     sails.services['token'].verify(token, function(error, token) {
-        if (error) {
-            sails.log.verbose('     ERROR - The token is not valid');
-
-            return response.json(401, {message: 'Given authorization token is not valid'});
-        } else {
+        if (_.isEmpty(error)) {
             sails.log.verbose('     OK');
 
             // Store user id to request object
             request.token = token;
 
             return next();
+        } else {
+            sails.log.verbose('     ERROR - The token is not valid');
+
+            return response.json(401, {message: 'Given authorization token is not valid'});
         }
     });
 };


### PR DESCRIPTION
JWT returns an empty object as error and the verify() method assumes it's an actual error; replaced verification with an _.isEmpty() call.
