### PR TITLE
Add Validation for empty Object in array

### DIFF
--- a/backend/api/hooks/load-db.js
+++ b/backend/api/hooks/load-db.js
@@ -20,7 +20,7 @@ module.exports = function hook(sails) {
         .exec(function callback(error, users) {
           if (error) {
             next(error);
-          } else if (users.length !== 0) {
+          } else if (users.length !== 0 && JSON.stringify(users[0]) !== '{}') {
             next();
           } else {
             sails.log.verbose(__filename + ':' + __line + ' [Hook.load-db] Populating database with fixture data...');


### PR DESCRIPTION
Hi,
I had the case that the user.find() function returned an array with an emtpy object {}

The array lenght was 1, so it did not populate with barrels. Can you add this code please so we will not have this problem furthermore :-)


greetz,
michael